### PR TITLE
MCT Switching Legend Display Name

### DIFF
--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/bridge/PlotConstants.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/bridge/PlotConstants.java
@@ -77,6 +77,7 @@ public class PlotConstants {
 	public static final long DEFAULT_TIME_AXIS_MAX_VALUE= DEFAULT_TIME_AXIS_MIN_VALUE  + DEFAULT_PLOT_SPAN;
 	public static final int  MAX_NUMBER_OF_DATA_ITEMS_ON_A_PLOT = 30;
 	public static final int  MAX_NUMBER_SUBPLOTS = 10;
+	public static final boolean DEFAULT_LEGEND_USE_LONG_NAMES = false;
 	public static final PlotLineDrawingFlags DEFAULT_PLOT_LINE_DRAW = new PlotLineDrawingFlags(true, false);
 	
 	public static final int MAJOR_TICK_MARK_LENGTH = 3;
@@ -117,6 +118,7 @@ public class PlotConstants {
 	public static final String LINE_SETTINGS = "PlotLineSettings";
 	public static final String FILTER_ENABLED = "PlotFilterEnabled";
 	public static final String FILTER_VALUE = "PlotFilterValue";
+	public static final String LEGEND_USE_LONG_NAMES = "PlotUseLongNames";
 
 	// Delay before firing a request for data at a higher resolution on a window. 
 	public final static int RESIZE_TIMER = 200; // in milliseconds.

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/LegendSetupPanel.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/LegendSetupPanel.java
@@ -1,0 +1,76 @@
+package gov.nasa.arc.mct.fastplot.settings;
+
+import gov.nasa.arc.mct.fastplot.bridge.PlotConstants;
+import gov.nasa.arc.mct.fastplot.settings.controls.PlotSettingsCheckBox;
+
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.GridBagLayout;
+import java.util.ResourceBundle;
+
+import javax.swing.AbstractButton;
+import javax.swing.JPanel;
+
+
+/**
+ * This class defines the UI for the Plot Configuration Panel
+ */
+public class LegendSetupPanel extends PlotSettingsPanel {
+	private static final long serialVersionUID = -521875198747937122L;
+	
+	// Access bundle file where externalized strings are defined.
+	private static final ResourceBundle BUNDLE = ResourceBundle
+			.getBundle("gov.nasa.arc.mct.fastplot.view.Bundle");
+	
+	private static final int TITLE_SPACING = 0;
+	
+	private PlotSettingsCheckBox useLongNamesCheckBox;
+	
+	public LegendSetupPanel() {
+		setLayout(new GridBagLayout());
+		
+		JPanel legendSetupPanel = new JPanel();
+    	legendSetupPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 0, TITLE_SPACING));
+    	useLongNamesCheckBox = new PlotSettingsCheckBox(BUNDLE.getString("UseLongNames.label")) {
+			private static final long serialVersionUID = 2725784642673926438L;
+
+			@Override
+			public boolean getFrom(PlotConfiguration settings) {
+				Boolean result = settings.getExtension(PlotConstants.LEGEND_USE_LONG_NAMES, Boolean.class);				
+				return result != null ? result : false;
+			}
+
+			@Override
+			public void populate(PlotConfiguration settings) {
+				settings.setExtension(PlotConstants.LEGEND_USE_LONG_NAMES, isSelected());
+			}
+    	};
+    	legendSetupPanel.add(useLongNamesCheckBox);
+    	addSubPanel(useLongNamesCheckBox);
+    	add(legendSetupPanel);
+		
+		for (Component c : getComponents()) {
+			if (c instanceof AbstractButton) {
+				((AbstractButton) c).addActionListener(this); // Trigger callbacks for any action
+			}
+		}
+	}
+	
+	@Override
+	public void populate(PlotConfiguration settings) {
+		boolean enabled = useLongNamesCheckBox.isSelected();
+		settings.setExtension(PlotConstants.LEGEND_USE_LONG_NAMES, enabled);
+	}
+
+	@Override
+	public void reset(PlotConfiguration settings, boolean hard) {
+		if (hard) {
+			useLongNamesCheckBox.reset(settings, hard);		
+		}
+	}
+
+	@Override
+	public boolean isValidated() {
+		return true;
+	}
+}

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotConfiguration.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotConfiguration.java
@@ -102,6 +102,10 @@ public interface PlotConfiguration {
 
 	public abstract PlotLineConnectionType getPlotLineConnectionType();
 
+	public abstract void setLegendUseLongNames(boolean legendUseLongName);
+
+	public abstract boolean getLegendUseLongNames();
+	
 	public abstract <T> T getExtension(String key, Class<T> extensionClass);
 	
 	public abstract <T> void setExtension(String key, T value);

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotConfigurationDelegator.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotConfigurationDelegator.java
@@ -352,6 +352,22 @@ public abstract class PlotConfigurationDelegator implements PlotConfiguration {
 	}
 
 	/**
+	 * @param minNonTime
+	 * @see gov.nasa.arc.mct.fastplot.settings.PlotConfiguration#setLegendUseLongNames(boolean)
+	 */
+	public void setLegendUseLongNames(boolean legendUseLongName) {
+		getDelegate().setLegendUseLongNames(legendUseLongName);
+	}
+
+	/**
+	 * @return
+	 * @see gov.nasa.arc.mct.fastplot.settings.PlotConfiguration#getLegendUseLongNames()
+	 */
+	public boolean getLegendUseLongNames() {
+		return getDelegate().getLegendUseLongNames();
+	}
+	
+	/**
 	 * @return
 	 * @see gov.nasa.arc.mct.fastplot.settings.PlotConfiguration#getPlotLineConnectionType()
 	 */

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotSettings.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotSettings.java
@@ -54,6 +54,7 @@ public class PlotSettings extends GenericSettings implements PlotConfiguration {
 		
 		this.create(PlotConstants.FILTER_ENABLED, Boolean.TRUE, Boolean.class);
 		this.create(PlotConstants.FILTER_VALUE, "", String.class);
+		this.create(PlotConstants.LEGEND_USE_LONG_NAMES, PlotConstants.DEFAULT_LEGEND_USE_LONG_NAMES, Boolean.class);
 		
 		// adjust default plot values according to plot.properties
 		Properties properties = getPlotDefaultProperties();
@@ -84,6 +85,10 @@ public class PlotSettings extends GenericSettings implements PlotConfiguration {
 				  else if (propertyName.equals("NonTimeMaxPadding")) { // change default non time min padding
 					  this.create(PlotConstants.NON_TIME_MIN_PADDING, Double.parseDouble(value), Double.class);
 				  }
+				  else if (propertyName.equals("PLOT_LEGEND_BY_TITLE")) { // change default plot legend by title long name
+					  this.create(PlotConstants.LEGEND_USE_LONG_NAMES, Boolean.parseBoolean(value), Boolean.class);
+				  }
+				  
 				}
 			}
 	}
@@ -542,6 +547,22 @@ public class PlotSettings extends GenericSettings implements PlotConfiguration {
 		return this.get(PlotConstants.CONNECTION_TYPE, PlotLineConnectionType.class);
 	}
 
+	/* (non-Javadoc)
+	 * @see gov.nasa.arc.mct.fastplot.settings.PlotConfiguration#setLegendUseLongNames(boolean)
+	 */
+	@Override
+	public void setLegendUseLongNames(boolean legendUseLongNames) {
+		this.set(PlotConstants.LEGEND_USE_LONG_NAMES, (Boolean) legendUseLongNames);
+	}
+
+	/* (non-Javadoc)
+	 * @see gov.nasa.arc.mct.fastplot.settings.PlotConfiguration#getLegendUseLongNames()
+	 */
+	@Override
+	public boolean getLegendUseLongNames() {
+		return this.get(PlotConstants.LEGEND_USE_LONG_NAMES, Boolean.class);
+	}
+	
 	@Override
 	public <T> T getExtension(String key, Class<T> extensionClass) {
 		return super.get(key, extensionClass);

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotSettingsControlArea.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/settings/PlotSettingsControlArea.java
@@ -1,9 +1,11 @@
 package gov.nasa.arc.mct.fastplot.settings;
 
 import gov.nasa.arc.mct.components.FeedFilterProvider;
+import gov.nasa.arc.mct.components.FeedProvider;
 import gov.nasa.arc.mct.fastplot.view.PlotViewManifestation;
 
 import java.awt.BorderLayout;
+import java.util.Collection;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -27,6 +29,10 @@ public class PlotSettingsControlArea extends PlotSettingsPanel {
 			add(new SectionPanel("Point Filtering", new PointFilteringPanel(filterProvider.createEditor())));
 		}
 		
+		Collection<FeedProvider> visibleFeedProviders = managedView.getVisibleFeedProviders();
+		if(!visibleFeedProviders.isEmpty()) {
+			add(new SectionPanel("Legend Setup", new LegendSetupPanel()));
+		}
 	}
 	
 	private class SectionPanel extends JPanel {

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/view/PlotDataAssigner.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/view/PlotDataAssigner.java
@@ -263,6 +263,7 @@ public class PlotDataAssigner {
 	void assignFeedsToSubPlots() {
 		assert feedsToPlot !=null : "Feeds to plot must be defined";
 		PlotView plot = plotViewManifestation.getPlot();
+		boolean useCanonicalName = plot.getExtension(PlotConstants.LEGEND_USE_LONG_NAMES, Boolean.class);
 
 		if (plot.getAxisOrientationSetting() == AxisOrientationSetting.Z_AXIS_AS_TIME) {
 			int count = 0;
@@ -293,16 +294,17 @@ public class PlotDataAssigner {
 				for (FeedProvider fp : feedsForSubPlot) {
 					if (numberOfItemsOnSubPlot < PlotConstants.MAX_NUMBER_OF_DATA_ITEMS_ON_A_PLOT) {
 						plot.addDataSet(subPlotNumber, fp.getSubscriptionId(),
-								fp.getLegendText());
+								getDisplayName(useCanonicalName, fp));
 						numberOfItemsOnSubPlot++;
 					}
 				}
 				subPlotNumber++;
 			}
-			
 		}
 
 	}
-
-
+	
+	private String getDisplayName(boolean useCanonicalName, FeedProvider provider) {
+		return useCanonicalName ? provider.getCanonicalName() : provider.getLegendText();
+	}
 }

--- a/fastPlotViews/src/main/resources/gov/nasa/arc/mct/fastplot/view/Bundle.properties
+++ b/fastPlotViews/src/main/resources/gov/nasa/arc/mct/fastplot/view/Bundle.properties
@@ -99,4 +99,4 @@ SelectCharacterDescription.label = Type a character for this plot line:
 RegressionLineLabel = Prediction Line
 RegressionPointsLabel = Set Points for Prediction Line...
 YearSpan = Years
-
+UseLongNames.label = Use long names

--- a/fastPlotViews/src/test/java/gov/nasa/arc/mct/fastplot/bridge/ShellPlotPackageImplementation.java
+++ b/fastPlotViews/src/test/java/gov/nasa/arc/mct/fastplot/bridge/ShellPlotPackageImplementation.java
@@ -678,5 +678,17 @@ public class ShellPlotPackageImplementation implements AbstractPlottingPackage{
 		// TODO Auto-generated method stub		
 	}
 
+	@Override
+	public void setLegendUseLongNames(boolean legendUseLongName) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public boolean getLegendUseLongNames() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
 
 }


### PR DESCRIPTION
- Added ability to switch the plot legend display name in new section "Legend Setup" in Plot configuration.
- Switches from FeedProvider.getLegendText() and Feedprovider.getCanonicalName();
- Default value is set to false to use FeedProvider.getLegendText(). Default value can be set using property "PLOT_LEGEND_BY_TITLE" in plot.properties file. 

Wrote or re-wrote unit tests (Y/N): N
 Ran entire suite of unit tests successfully (Y/N): Y
 Verified bug fix with the described replication steps or verified the implementation meets the requirement cited (Y/N): -
 Code coverage requirements satisfied (new code=80%, changed code=at least as high as existing) (Y/N):
 Code review date and attendees:
 Describe potential impact on other areas of the code: Plot
 Describe any test prerequisites for this fix (e.g., restart the database): -
 For bugs marked "Regression - Yes", describe the cause of the regression:
 Did you modify any pom.xml file? If yes, did you thoroughly document your changes and reasons? N