### PR TITLE
Plot Augmentation fix: Streaming data does not graph the data in the

### DIFF
--- a/Plotter/src/main/java/plotter/xy/XYPlotContents.java
+++ b/Plotter/src/main/java/plotter/xy/XYPlotContents.java
@@ -57,7 +57,35 @@ public class XYPlotContents extends JComponent {
 		plot.toLogical(dest, loc);
 	}
 
+	/**
+	 * Converts to physical value
+	 * @param d The logical value to be converted
+	 * @param isXAxisAsTime flag if the X-Axis is Time
+	 * @return the physical value
+	 */
+	public int toPhysical(double d, boolean isXAxisAsTime) {
+		XYPlot xyPlot = (XYPlot) getParent();
+		
+		if(isXAxisAsTime) {
+			int yOffset = xyPlot.getContents().getY();
+			XYAxis yAxis = xyPlot.getYAxis();
+			double min = yAxis.getStart();
+			double max = yAxis.getEnd();
+			int endMargin = yAxis.getEndMargin();
+			int height = yAxis.getHeight() - yAxis.getStartMargin();
+			return height - (int) ((d - min) / (max - min) * (height - endMargin) + .5) - yOffset;
 
+		} else {
+			XYAxis xAxis = xyPlot.getXAxis();
+			double minX = xAxis.getEnd();
+			double maxX = xAxis.getStart();
+			int endMarginX = xAxis.getEndMargin();
+			int height = xAxis.getWidth() - xAxis.getStartMargin();
+			return height - (int) ((d - minX) / (maxX - minX) * (height - endMarginX) + .5);
+		}
+	}
+	
+	
 	@Override
 	public boolean isValidateRoot() {
 		return true;

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/bridge/PlotterPlot.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/bridge/PlotterPlot.java
@@ -43,7 +43,6 @@ import gov.nasa.arc.mct.services.activity.TimeService;
 
 import java.awt.Color;
 import java.awt.Font;
-import java.awt.Graphics;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.text.NumberFormat;
@@ -68,8 +67,6 @@ import plotter.xy.CompressingXYDataset;
 import plotter.xy.LinearXYAxis;
 import plotter.xy.XYAxis;
 import plotter.xy.XYPlot;
-import plotter.xy.XYPlotAugmentationContents;
-import plotter.xy.XYPlotContents;
 
 /**
  * Provides the implementation of the general plotting package interface using the Fast plot 
@@ -257,9 +254,6 @@ public class PlotterPlot  extends PlotConfigurationDelegator implements Abstract
 	    // Create the quinn curtis objects that make up the
 	    // physical plot. 
 	    setupPlotObjects();
-
-	    // Setup any Plot Augmentation
-	    setupPlotAugmentation();
 	    
 		// Setup the limit manager. 
 	    setupLimitManager();
@@ -289,34 +283,6 @@ public class PlotterPlot  extends PlotConfigurationDelegator implements Abstract
 	
 	private void setupPlotObjects() {
 		new QCPlotObjects(this);	
-	}
-	
-	/**
-	 *  Plot Augmentation setup
-	 */
-	private void setupPlotAugmentation() {
-		XYPlotContents plotAugmentation = new XYPlotAugmentationContents(getPlotView()) {
-			private static final long serialVersionUID = 9059094109383625272L;
-			
-			@Override
-			public void paintComponent(Graphics og) {
-				super.paintComponent(og);
-				og.setColor(getBackground());
-				og.fillRect(0, 0, getWidth(), getHeight());
-
-				if(pac != null) {
-					double minNonTime = getMinNonTime();
-					double maxNonTime = getMaxNonTime();
-					pac.setMinNonTime(minNonTime);
-					pac.setMaxNonTime(maxNonTime);
-					pac.setXAxisAsTime(getAxisOrientationSetting() == AxisOrientationSetting.X_AXIS_AS_TIME);
-					
-					// Draw the Plot Augmentation
-					pac.draw(this, getBounds());
-				}
-	        }
-		};
-		getPlotView().getContents().add(plotAugmentation);
 	}
 	
 	private void setupListeners() {
@@ -1484,5 +1450,9 @@ public class PlotterPlot  extends PlotConfigurationDelegator implements Abstract
 	@Override
 	public void setPlotAugmentation(PlotAugmentationCapability pac) {
 		this.pac = pac;
+	}
+	
+	public PlotAugmentationCapability getPlotAugmentation() {
+		return pac;
 	}
 }

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/bridge/QCPlotObjects.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/bridge/QCPlotObjects.java
@@ -26,11 +26,13 @@ import gov.nasa.arc.mct.fastplot.bridge.PlotConstants.NonTimeAxisSubsequentBound
 import gov.nasa.arc.mct.fastplot.bridge.PlotConstants.TimeAxisSubsequentBoundsSetting;
 import gov.nasa.arc.mct.fastplot.bridge.PlotConstants.XAxisMaximumLocationSetting;
 import gov.nasa.arc.mct.fastplot.bridge.PlotConstants.YAxisMaximumLocationSetting;
+import gov.nasa.arc.mct.fastplot.component.PlotAugmentationCapability;
 import gov.nasa.arc.mct.fastplot.utils.MouseRedispatcher;
 import gov.nasa.arc.mct.fastplot.utils.TimeFormatUtils;
 
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Graphics;
 import java.awt.event.MouseAdapter;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -65,7 +67,29 @@ public class QCPlotObjects {
 		// Create new instance of the plot 
 		plot.setPlotView(new XYPlot());
 		plot.getPlotView().setBackground(PlotConstants.DEFAULT_PLOT_FRAME_BACKGROUND_COLOR);
-		XYPlotContents contents = new XYPlotContents();
+		XYPlotContents contents = new XYPlotContents() {
+
+			private static final long serialVersionUID = -4849699424575359444L;
+
+			@Override
+			public void paintComponent(Graphics og) {
+				super.paintComponent(og);
+				og.setColor(getBackground());
+				og.fillRect(0, 0, getWidth(), getHeight());
+				
+				PlotAugmentationCapability pac = plot.getPlotAugmentation();
+				if(pac != null) {
+					double minNonTime = plot.getMinNonTime();
+					double maxNonTime = plot.getMaxNonTime();
+					pac.setMinNonTime(minNonTime);
+					pac.setMaxNonTime(maxNonTime);
+					pac.setXAxisAsTime(plot.getAxisOrientationSetting() == AxisOrientationSetting.X_AXIS_AS_TIME);
+					
+					// Draw the Plot Augmentation
+					pac.draw(this, getBounds());
+				}
+	        }
+		};
 		contents.setBackground(Color.black);
 		plot.getPlotView().add(contents);
 		plot.getPlotView().setPreferredSize(new Dimension(PlotterPlot.PLOT_PREFERED_WIDTH, PlotterPlot.PLOT_PREFERED_HEIGHT));

--- a/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/component/PlotAugmentationCapability.java
+++ b/fastPlotViews/src/main/java/gov/nasa/arc/mct/fastplot/component/PlotAugmentationCapability.java
@@ -5,7 +5,7 @@ import gov.nasa.arc.mct.components.FeedProvider;
 import java.awt.geom.Rectangle2D;
 import java.util.Collection;
 
-import plotter.xy.XYPlotAugmentationContents;
+import plotter.xy.XYPlotContents;
 
 /**
  * Represents a viewed object to provide additional drawings on top of a plot.
@@ -19,7 +19,7 @@ public interface PlotAugmentationCapability {
 	 * @param xyPlotContents
 	 * @param dataBounds
 	 */
-	public void draw(XYPlotAugmentationContents xyPlotContents, Rectangle2D dataBounds);
+	public void draw(XYPlotContents xyPlotContents, Rectangle2D dataBounds);
 
 	/**
 	 * Method to obtain the FeedProviders associated to the plot.


### PR DESCRIPTION
Plot view, although in the Alpha view it does show data being received.
- Removed extra XYPlotAugmentationContents JComponent layer and simply
used the existing XYPlotContents for any additional augmenting drawings
(i.e. Drawing additional Limit Lines on the Plot view graph).

Wrote or re-wrote unit tests (Y/N): N
Ran entire suite of unit tests successfully (Y/N): Y
Verified bug fix with the described replication steps or verified the implementation meets the requirement cited (Y/N): -
Code coverage requirements satisfied (new code=80%, changed code=at least as high as existing) (Y/N): N
Code review date and attendees: On pull request.
Describe potential impact on other areas of the code: Plot
Describe any test prerequisites for this fix (e.g., restart the database):
For bugs marked "Regression - Yes", describe the cause of the regression:
Did you modify any pom.xml file? If yes, did you thoroughly document your changes and reasons? N
