### PR TITLE
Removing Objects > Import menu option when there is no valid component selected

### DIFF
--- a/databasePersistence/src/main/java/gov/nasa/arc/mct/dbpersistence/service/PersistenceServiceImpl.java
+++ b/databasePersistence/src/main/java/gov/nasa/arc/mct/dbpersistence/service/PersistenceServiceImpl.java
@@ -124,7 +124,19 @@ public class PersistenceServiceImpl implements PersistenceProvider {
 		private static final long serialVersionUID = 1834331905999908621L;
 
 		public int compare(AbstractComponent o1, AbstractComponent o2) {
-			return o1.getComponentId().compareTo(o2.getComponentId());
+			// Handles null situations
+			if(o1.getComponentId() == null) {
+		         if(o2.getComponentId() == null)
+		            return 0; //equal
+		         else
+		            return -1; // null is before other strings
+			}
+			else {
+		         if(o2.getComponentId() == null)
+		            return 1;  // all other strings are after null
+		         else
+		            return o1.getComponentId().compareTo(o2.getComponentId());
+			}
 		}
 	}
 	

--- a/databasePersistence/src/main/java/gov/nasa/arc/mct/dbpersistence/service/PersistenceServiceImpl.java
+++ b/databasePersistence/src/main/java/gov/nasa/arc/mct/dbpersistence/service/PersistenceServiceImpl.java
@@ -125,17 +125,18 @@ public class PersistenceServiceImpl implements PersistenceProvider {
 
 		public int compare(AbstractComponent o1, AbstractComponent o2) {
 			// Handles null situations
-			if(o1.getComponentId() == null) {
-		         if(o2.getComponentId() == null)
-		            return 0; //equal
-		         else
-		            return -1; // null is before other strings
-			}
-			else {
-		         if(o2.getComponentId() == null)
-		            return 1;  // all other strings are after null
-		         else
-		            return o1.getComponentId().compareTo(o2.getComponentId());
+			if (o1.getComponentId() == null) {
+				if (o2.getComponentId() == null) {
+					return 0; // equal
+				} else {
+					return -1; // null is before other strings
+				}
+			} else {
+				if (o2.getComponentId() == null) {
+					return 1; // all other strings are after null
+				} else {
+					return o1.getComponentId().compareTo(o2.getComponentId());
+				}
 			}
 		}
 	}

--- a/platform/src/main/java/gov/nasa/arc/mct/gui/menu/ImportMenu.java
+++ b/platform/src/main/java/gov/nasa/arc/mct/gui/menu/ImportMenu.java
@@ -50,7 +50,12 @@ public abstract class ImportMenu extends ContextAwareMenu {
 
     @Override
     public boolean canHandle(ActionContext context) {
-        return true;
+        Collection<View> selection = context.getSelectedManifestations();
+        boolean empty = selection.isEmpty();
+        return !empty && isWritable(selection
+                .iterator()
+                .next()
+                .getManifestedComponent());
     }
 
     protected boolean isWritable(AbstractComponent targetComponent) {

--- a/platform/src/main/java/gov/nasa/arc/mct/gui/menu/housing/ThisMenu.java
+++ b/platform/src/main/java/gov/nasa/arc/mct/gui/menu/housing/ThisMenu.java
@@ -50,7 +50,7 @@ public class ThisMenu extends ContextAwareMenu {
 
     @Override
     public boolean canHandle(ActionContext context) {
-        return false;
+        return context.getSelectedManifestations().isEmpty();
     }
     
     @Override

--- a/platform/src/main/java/gov/nasa/arc/mct/gui/menu/housing/ThisMenu.java
+++ b/platform/src/main/java/gov/nasa/arc/mct/gui/menu/housing/ThisMenu.java
@@ -50,7 +50,7 @@ public class ThisMenu extends ContextAwareMenu {
 
     @Override
     public boolean canHandle(ActionContext context) {
-        return context.getSelectedManifestations().isEmpty();
+        return !context.getSelectedManifestations().isEmpty();
     }
     
     @Override

--- a/platform/src/main/java/gov/nasa/arc/mct/gui/menu/housing/ThisMenu.java
+++ b/platform/src/main/java/gov/nasa/arc/mct/gui/menu/housing/ThisMenu.java
@@ -50,7 +50,7 @@ public class ThisMenu extends ContextAwareMenu {
 
     @Override
     public boolean canHandle(ActionContext context) {
-        return true;
+        return false;
     }
     
     @Override

--- a/platform/src/test/java/gov/nasa/arc/mct/gui/menu/TestImportExportMenus.java
+++ b/platform/src/test/java/gov/nasa/arc/mct/gui/menu/TestImportExportMenus.java
@@ -153,6 +153,8 @@ public class TestImportExportMenus {
         // If policy allows, then canHandle should be true
         Mockito.when(mockPolicy.execute(Mockito.eq(compositionKey), Mockito.<PolicyContext>any()))
             .thenReturn(new ExecutionResult(null, true, ""));
+        Mockito.when(mockContext.getSelectedManifestations()).thenReturn(Arrays.asList(mockView));
+        Mockito.when(mockView.getManifestedComponent()).thenReturn(mockComponent);
         Assert.assertTrue(thisMenu.canHandle(mockContext));
         
         

--- a/platform/src/test/java/gov/nasa/arc/mct/gui/menu/TestStandardHousingMenuBar.java
+++ b/platform/src/test/java/gov/nasa/arc/mct/gui/menu/TestStandardHousingMenuBar.java
@@ -174,7 +174,7 @@ public class TestStandardHousingMenuBar {
         
         MockHousing housing = new MockHousing(0, 0, 0, MCTHousingFactory.DIRECTORY_AREA_ENABLE, new MCTHousingViewManifestation(componentA,new ViewInfo(MCTHousingViewManifestation.class,"",ViewType.LAYOUT)));
         MCTStandardHousingMenuBar standardMenuBar = new MCTStandardHousingMenuBar(housing);
-        Assert.assertEquals(standardMenuBar.getMenuCount(), 6);
+        Assert.assertEquals(standardMenuBar.getMenuCount(), 5);
 
         for (int i = 0; i < standardMenuBar.getMenuCount(); i++) {
             Assert.assertFalse(standardMenuBar.getMenu(i) instanceof EditMenu);
@@ -190,7 +190,7 @@ public class TestStandardHousingMenuBar {
         
         MockHousing housing = new MockHousing(0, 0, 0, MCTHousingFactory.DIRECTORY_AREA_ENABLE, new MCTHousingViewManifestation(componentB,new ViewInfo(MCTHousingViewManifestation.class,"",ViewType.LAYOUT)));
         MCTStandardHousingMenuBar standardMenuBar = new MCTStandardHousingMenuBar(housing);
-        Assert.assertEquals(standardMenuBar.getMenuCount(), 6);
+        Assert.assertEquals(standardMenuBar.getMenuCount(), 5);
 
         for (int i = 0; i < standardMenuBar.getMenuCount(); i++) {
             Assert.assertFalse(standardMenuBar.getMenu(i) instanceof EditMenu);
@@ -213,7 +213,7 @@ public class TestStandardHousingMenuBar {
 
         MockHousing housing = new MockHousing(0, 0, 0, MCTHousingFactory.CONTENT_AREA_ENABLE, new MCTHousingViewManifestation(componentC,new ViewInfo(MCTHousingViewManifestation.class,"",ViewType.LAYOUT)));
         MCTStandardHousingMenuBar standardMenuBar = new MCTStandardHousingMenuBar(housing);
-        Assert.assertEquals(standardMenuBar.getMenuCount(), 6);
+        Assert.assertEquals(standardMenuBar.getMenuCount(), 5);
 
         ActionContextImpl context = new ActionContextImpl();
         context.setTargetHousing(housing);

--- a/platform/src/test/java/gov/nasa/arc/mct/gui/menu/TestStandardHousingMenuBar.java
+++ b/platform/src/test/java/gov/nasa/arc/mct/gui/menu/TestStandardHousingMenuBar.java
@@ -174,7 +174,7 @@ public class TestStandardHousingMenuBar {
         
         MockHousing housing = new MockHousing(0, 0, 0, MCTHousingFactory.DIRECTORY_AREA_ENABLE, new MCTHousingViewManifestation(componentA,new ViewInfo(MCTHousingViewManifestation.class,"",ViewType.LAYOUT)));
         MCTStandardHousingMenuBar standardMenuBar = new MCTStandardHousingMenuBar(housing);
-        Assert.assertEquals(standardMenuBar.getMenuCount(), 5);
+        Assert.assertEquals(standardMenuBar.getMenuCount(), 6);
 
         for (int i = 0; i < standardMenuBar.getMenuCount(); i++) {
             Assert.assertFalse(standardMenuBar.getMenu(i) instanceof EditMenu);
@@ -190,7 +190,7 @@ public class TestStandardHousingMenuBar {
         
         MockHousing housing = new MockHousing(0, 0, 0, MCTHousingFactory.DIRECTORY_AREA_ENABLE, new MCTHousingViewManifestation(componentB,new ViewInfo(MCTHousingViewManifestation.class,"",ViewType.LAYOUT)));
         MCTStandardHousingMenuBar standardMenuBar = new MCTStandardHousingMenuBar(housing);
-        Assert.assertEquals(standardMenuBar.getMenuCount(), 5);
+        Assert.assertEquals(standardMenuBar.getMenuCount(), 6);
 
         for (int i = 0; i < standardMenuBar.getMenuCount(); i++) {
             Assert.assertFalse(standardMenuBar.getMenu(i) instanceof EditMenu);
@@ -213,7 +213,7 @@ public class TestStandardHousingMenuBar {
 
         MockHousing housing = new MockHousing(0, 0, 0, MCTHousingFactory.CONTENT_AREA_ENABLE, new MCTHousingViewManifestation(componentC,new ViewInfo(MCTHousingViewManifestation.class,"",ViewType.LAYOUT)));
         MCTStandardHousingMenuBar standardMenuBar = new MCTStandardHousingMenuBar(housing);
-        Assert.assertEquals(standardMenuBar.getMenuCount(), 5);
+        Assert.assertEquals(standardMenuBar.getMenuCount(), 6);
 
         ActionContextImpl context = new ActionContextImpl();
         context.setTargetHousing(housing);


### PR DESCRIPTION
Removing Objects > Import menu option when there is no valid component selected in the Browse tree. This option shows when the user is admin. The regular user does not see this option.

Reference Jira: ChillPlots - MPCS-7522.

- Handles null cases.
- ThisMenu canHandle set to false.

Wrote or re-wrote unit tests (Y/N): Y
 Ran entire suite of unit tests successfully (Y/N): Y
 Verified bug fix with the described replication steps or verified the implementation meets the requirement cited (Y/N): Y
 Code coverage requirements satisfied (new code=80%, changed code=at least as high as existing) (Y/N): N
 Code review date and attendees: On pull request
 Describe potential impact on other areas of the code: menu
 Describe any test prerequisites for this fix (e.g., restart the database):
 For bugs marked "Regression - Yes", describe the cause of the regression:
 Did you modify any pom.xml file? If yes, did you thoroughly document your changes and reasons? N